### PR TITLE
Add IMD neighbour imputation notebook

### DIFF
--- a/notebooks/07_IMD_Neighbour_Methods.ipynb
+++ b/notebooks/07_IMD_Neighbour_Methods.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 07_IMD_Neighbour_Methods\n",
+    "\n",
+    "Test multiple approaches for deriving missing IMD scores using neighbouring LSOAs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import geopandas as gpd\n",
+    "from sklearn.neighbors import NearestNeighbors\n",
+    "import numpy as np\n",
+    "\n",
+    "RAW_DATA_DIR = '../data/raw'\n",
+    "PROCESSED_DATA_DIR = '../data/processed'\n",
+    "LSOA_SW_PATH = os.path.join(PROCESSED_DATA_DIR, 'lsoa_sw_enriched_demographics.gpkg')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load enriched LSOA data\n",
+    "lsoa_sw = gpd.read_file(LSOA_SW_PATH, layer='lsoa_sw_enriched_demographics')\n",
+    "lsoa_sw['centroid'] = lsoa_sw.geometry.centroid\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def impute_imd_knn_mean(gdf, imd_col='IMD_Rank', k=5):\n",
+    "    coords = np.array([(geom.x, geom.y) for geom in gdf['centroid']])\n",
+    "    missing = gdf[imd_col].isna()\n",
+    "    nn = NearestNeighbors(n_neighbors=k).fit(coords[~missing])\n",
+    "    d, idx = nn.kneighbors(coords[missing])\n",
+    "    gdf.loc[missing, imd_col] = gdf.loc[~missing, imd_col].values[idx].mean(axis=1)\n",
+    "    return gdf\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def impute_imd_knn_median(gdf, imd_col='IMD_Rank', k=5):\n",
+    "    coords = np.array([(geom.x, geom.y) for geom in gdf['centroid']])\n",
+    "    missing = gdf[imd_col].isna()\n",
+    "    nn = NearestNeighbors(n_neighbors=k).fit(coords[~missing])\n",
+    "    d, idx = nn.kneighbors(coords[missing])\n",
+    "    gdf.loc[missing, imd_col] = np.median(gdf.loc[~missing, imd_col].values[idx], axis=1)\n",
+    "    return gdf\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def impute_imd_knn_distance_weighted(gdf, imd_col='IMD_Rank', k=5, epsilon=1e-8):\n",
+    "    coords = np.array([(geom.x, geom.y) for geom in gdf['centroid']])\n",
+    "    missing = gdf[imd_col].isna()\n",
+    "    nn = NearestNeighbors(n_neighbors=k).fit(coords[~missing])\n",
+    "    d, idx = nn.kneighbors(coords[missing])\n",
+    "    weights = 1.0 / (d + epsilon)\n",
+    "    values = gdf.loc[~missing, imd_col].values[idx]\n",
+    "    gdf.loc[missing, imd_col] = np.sum(values * weights, axis=1) / np.sum(weights, axis=1)\n",
+    "    return gdf\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example usage (choose one method)\n",
+    "# lsoa_sw = impute_imd_knn_mean(lsoa_sw.copy())\n",
+    "# lsoa_sw = impute_imd_knn_median(lsoa_sw.copy())\n",
+    "# lsoa_sw = impute_imd_knn_distance_weighted(lsoa_sw.copy())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new notebook `07_IMD_Neighbour_Methods.ipynb` showing different ways of estimating IMD using neighbouring LSOAs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a6e976f483269c137af074ed8554